### PR TITLE
fix: Overly aggressive `content_scripts.matches`

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,9 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.twitch.tv/*"
+        "https://www.twitch.tv/*",
+        "https://player.twitch.tv/*",
+        "https://clips.twitch.tv/*"
       ],
       "js": [
         "ts/content.ts"
@@ -45,7 +47,9 @@
     "webRequest",
     "webRequestBlocking",
     "http://localhost/*",
-    "https://*.twitch.tv/*",
+    "https://www.twitch.tv/*",
+    "https://player.twitch.tv/*",
+    "https://clips.twitch.tv/*",
     "https://usher.ttvnw.net/*",
     "https://*.amazon-adsystem.com/*"
   ]


### PR DESCRIPTION
I ran into a problem where this web-extension tried to proxy videos under `dashboard.twitch.tv`, that obviously won't work, due to private vod access requiring token authentication. Moving from a wildcard to stricter domain stating fixes this problem.